### PR TITLE
Add script to allow local running of test-runner container

### DIFF
--- a/bin/run-local.sh
+++ b/bin/run-local.sh
@@ -1,0 +1,15 @@
+#!/bin/sh -e
+
+slug=$1
+local_input=`realpath $2`
+local_output=`realpath $3`
+
+image=`docker build -q .`
+
+docker run \
+       --mount type=bind,source=${local_input},target=/input \
+       --mount type=bind,source=${local_output},target=/output \
+       --rm \
+       -it $image $slug /input/ /output/
+
+docker image rm $image


### PR DESCRIPTION
* Same arguments as actual run.sh. 
* Mounts local input & output directories into the container. 
* Cleans up the container and image after itself.

example:

```
./bin/run-local.sh basics ../v3/languages/common-lisp/exercises/concept/basics .
```

This will result in a `results.json` file being written to the local
directory. All stdout/stderr output will be to the current terminal.