### PR TITLE
Only copy the needed files in the Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -10,6 +10,6 @@ RUN sbcl --load quicklisp.lisp \
          --eval '(quicklisp-quickstart:install)' \
          --eval "(ql:quickload '(:fiveam :dissect :st-json))" --quit
 # Copy over the test runner
-COPY bin/ bin/
+COPY bin/run.lisp /bin/run.sh bin/
 # Set test runner as the ENTRYPOINT
 ENTRYPOINT ["sh", "bin/run.sh"]


### PR DESCRIPTION
This fixes the `run-local.sh` or any hidden autosave files in the `bin/` directory from getting copied into the image.