### PR TITLE
Remove unhelpful stack traces and restarts

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -8,8 +8,8 @@ ADD https://beta.quicklisp.org/quicklisp.lisp .
 # Install Quicklisp and load FiveAM
 RUN sbcl --load quicklisp.lisp \
          --eval '(quicklisp-quickstart:install)' \
-         --eval "(ql:quickload '(:fiveam :dissect :st-json))" --quit
+         --eval "(ql:quickload '(:fiveam :st-json))" --quit
 # Copy over the test runner
-COPY bin/run.lisp /bin/run.sh bin/
+COPY bin/run.lisp bin/run.sh bin/
 # Set test runner as the ENTRYPOINT
 ENTRYPOINT ["sh", "bin/run.sh"]

--- a/bin/run.lisp
+++ b/bin/run.lisp
@@ -25,7 +25,7 @@
 (defmethod process-test-result ((result 5am::unexpected-test-failure))
   (st-json:jso "name" (get-test-description result)
                "status" "error"
-               "message" (format nil "~a" (5am::actual-condition result))
+               "message" (princ-to-string (5am::actual-condition result))
                "output" :null))
 
 (defmethod process-test-result ((result 5am::test-failure))
@@ -62,7 +62,7 @@
 
 (defun generate-report (results &optional error)
   (st-json:jso "status" (results-status results)
-               "message" (unless results (format nil "~a" error))
+               "message" (unless results (princ-to-string error))
                "tests" (remove nil (mapcar #'process-test-result results))))
 
 ;;; Invoke the test-runner

--- a/bin/run.lisp
+++ b/bin/run.lisp
@@ -2,7 +2,7 @@
 
 ;;; Setup Quicklisp & FiveAM
 (load "/root/quicklisp/setup.lisp")
-(ql:quickload '(:fiveam :dissect :st-json))
+(ql:quickload '(:fiveam :st-json))
 
 ;;; Set some parameters
 (defvar *max-output-chars* 500)
@@ -25,7 +25,7 @@
 (defmethod process-test-result ((result 5am::unexpected-test-failure))
   (st-json:jso "name" (get-test-description result)
                "status" "error"
-               "message" (dissect:present (5am::actual-condition result) nil)
+               "message" (format nil "~a" (5am::actual-condition result))
                "output" :null))
 
 (defmethod process-test-result ((result 5am::test-failure))
@@ -62,7 +62,7 @@
 
 (defun generate-report (results &optional error)
   (st-json:jso "status" (results-status results)
-               "message" (unless results (dissect:present error nil))
+               "message" (unless results (format nil "~a" error))
                "tests" (remove nil (mapcar #'process-test-result results))))
 
 ;;; Invoke the test-runner


### PR DESCRIPTION
I love it when changes make things simpler! We technically need to bug @exercism/ops, but we are just removing a dependency from the Dockerfile. This PR turns error messages that looked like this:

```
READ error during LOAD:

  end of file on #<SB-INT:FORM-TRACKING-STREAM for "file /mnt/exercism-iteration/common-lisp-1-a.lisp" {1003EB1503}>

  (in form starting at line: 36, column: 0, position: 1095)
   [Condition of type SB-C::INPUT-ERROR-IN-LOAD]

#<ENVIRONMENT {100443EEC3}>
   [Environment of thread #<THREAD "main thread" RUNNING {1000508083}>]

Available restarts:
 0: [RETRY] Retry EVAL of current toplevel form.
 1: [CONTINUE] Ignore error and continue loading file "/opt/test-runner/bin/run.lisp".
 2: [ABORT] Abort loading file "/opt/test-runner/bin/run.lisp".
 3: [ABORT] Abort script, exiting lisp.

Backtrace:
 7: (GENERATE-REPORT NIL READ error during LOAD: end of file on #<SB-INT:FORM-TRACKING-STREAM for "file /mnt/exercism-iteration/common-lisp-1-a.lisp" {1003EB1503}>(in form starting at line: 36, column: 0, position: 1095))
 8: (TEST-RUNNER)
 9: (SB-INT:SIMPLE-EVAL-IN-LEXENV (TEST-RUNNER) #<NULL-LEXENV>)
 10: (EVAL-TLF (TEST-RUNNER) 15 NIL)
 11: ((LABELS SB-FASL::EVAL-FORM :IN SB-INT:LOAD-AS-SOURCE) (TEST-RUNNER) 15)
 12: ((LAMBDA (SB-KERNEL:FORM &KEY :CURRENT-INDEX &ALLOW-OTHER-KEYS) :IN SB-INT:LOAD-AS-SOURCE) (TEST-RUNNER) CURRENT-INDEX 15)
 13: (SB-C::%DO-FORMS-FROM-INFO #<CLOSURE (LAMBDA (SB-KERNEL:FORM &KEY :CURRENT-INDEX &ALLOW-OTHER-KEYS) :IN SB-INT:LOAD-AS-SOURCE) {1001549BCB}> #<SOURCE-INFO {1001549B93}> INPUT-ERROR-IN-LOAD)
 14: (SB-INT:LOAD-AS-SOURCE #<FD-STREAM for "file /opt/test-runner/bin/run.lisp" {100153B293}> VERBOSE NIL PRINT NIL CONTEXT loading)
 15: ((FLET SB-FASL::THUNK :IN LOAD))
 16: (SB-FASL::CALL-WITH-LOAD-BINDINGS #<CLOSURE (FLET SB-FASL::THUNK :IN LOAD) {7F7070A6769B}> #<FD-STREAM for "file /opt/test-runner/bin/run.lisp" {100153B293}>)
 17: ((FLET SB-FASL::LOAD-STREAM :IN LOAD) #<FD-STREAM for "file /opt/test-runner/bin/run.lisp" {100153B293}> NIL)
 18: (LOAD #<FD-STREAM for "file /opt/test-runner/bin/run.lisp" {100153B293}> VERBOSE NIL PRINT NIL IF-DOES-NOT-EXIST T EXTERNAL-FORMAT DEFAULT)
 19: ((FLET SB-IMPL::LOAD-SCRIPT :IN SB-IMPL::PROCESS-SCRIPT) #<FD-STREAM for "file /opt/test-runner/bin/run.lisp" {100153B293}>)
 20: ((FLET SB-UNIX::BODY :IN SB-IMPL::PROCESS-SCRIPT))
 21: ((FLET "WITHOUT-INTERRUPTS-BODY-2" :IN SB-IMPL::PROCESS-SCRIPT))
 22: (SB-IMPL::PROCESS-SCRIPT bin/run.lisp)
 23: (SB-IMPL::TOPLEVEL-INIT)
 24: ((FLET SB-UNIX::BODY :IN SAVE-LISP-AND-DIE))
 25: ((FLET "WITHOUT-INTERRUPTS-BODY-7" :IN SAVE-LISP-AND-DIE))
 26: ((LABELS SB-IMPL::RESTART-LISP :IN SAVE-LISP-AND-DIE))
```

Into something a bit more reasonable:

```
READ error during LOAD:

  end of file on #<SB-INT:FORM-TRACKING-STREAM for "file /input/common-lisp-1-a.lisp" {1003D7CF03}>

  (in form starting at line: 36, column: 0, position: 1095)
```