### PR TITLE
Update to use clfoundation sbcl image.

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,30 +1,29 @@
-FROM daewok/sbcl:alpine AS build
-RUN apk update && apk upgrade
+FROM clfoundation/sbcl:2.1.5-alpine3.13 AS build
+RUN apk --no-cache add curl
 
 # Set working directory
 WORKDIR /opt/test-runner
-ENV HOME /opt/test-runner
+ENV HOME=/opt/test-runner
 
 # Pull down the latest Quicklisp
-ADD https://beta.quicklisp.org/quicklisp.lisp quicklisp/
+RUN mkdir build && curl https://beta.quicklisp.org/quicklisp.lisp -o build/quicklisp.lisp
 
 # Install quicklisp
 COPY build/install-quicklisp.lisp build/
 RUN sbcl --script build/install-quicklisp.lisp
 
-# Build the test-runner
+# Build the application
 COPY build/build.lisp build/
 COPY src quicklisp/local-projects/test-runner
 RUN sbcl --script ./build/build.lisp
 
 # Build the runtime image
-FROM alpine
+FROM alpine:3.13
 WORKDIR /opt/test-runner
 
 # Copy over the test-runner code
-COPY --from=build /opt/test-runner/test-runner bin/
-COPY --from=build /opt/test-runner/.cache/common-lisp/ .cache/common-lisp/
+COPY --from=build /opt/test-runner/bin/ bin/
 COPY bin/run.sh bin/
 
-# Set test runner as the ENTRYPOINT
-ENTRYPOINT ["sh", "bin/run.sh"]
+# Set test-runner script as the ENTRYPOINT
+ENTRYPOINT ["bin/run.sh"]

--- a/build/build.lisp
+++ b/build/build.lisp
@@ -1,6 +1,8 @@
-(load "quicklisp/setup")
+(load "quicklisp/setup.lisp")
 (ql:quickload "test-runner")
 
-(sb-ext:save-lisp-and-die "test-runner"
+(let ((bin-dir (make-pathname :directory '(:relative "bin"))))
+  (ensure-directories-exist bin-dir)
+  (sb-ext:save-lisp-and-die (merge-pathnames "test-runner" bin-dir)
                           :toplevel #'test-runner:test-runner
-                          :executable t)
+                          :executable t))

--- a/build/install-quicklisp.lisp
+++ b/build/install-quicklisp.lisp
@@ -1,2 +1,2 @@
-(load "quicklisp/quicklisp.lisp")
+(load "build/quicklisp.lisp")
 (quicklisp-quickstart:install)


### PR DESCRIPTION
This change also includes a switch from ADD to RUN curl to get
quicklisp. ADD was giving a 'invalid not-modifed Etag' error which
kept the image from building.

Fixes #29