### PR TITLE
Fixing problem introduced with Dockerfile update

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -23,6 +23,7 @@ WORKDIR /opt/test-runner
 
 # Copy over the test-runner code
 COPY --from=build /opt/test-runner/bin/ bin/
+COPY --from=build /opt/test-runner/.cache/common-lisp/ .cache/common-lisp/
 COPY bin/run.sh bin/
 
 # Set test-runner script as the ENTRYPOINT


### PR DESCRIPTION
Test-runner is special in that at *run-time* a QuickLisp system will
be loaded (fiveam during the loading of the test file). So we need to
make sure that exists in the built image to make sure it will be found
during run-time.

When updating the Dockerfile the single important line was missed from
the old Dockerfile. And, embarrassingly, the simple manual test to
check the build image was not executed (silly me).